### PR TITLE
Fix module imports in tests to avoid ModuleNotFoundError

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,0 +1,24 @@
+name: Python package
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.x'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+    - name: Run tests
+      run: |
+        pytest -q

--- a/tests/test_backup_manager.py
+++ b/tests/test_backup_manager.py
@@ -2,7 +2,10 @@ import tempfile
 import os
 import sys
 
-sys.path.insert(0, os.getcwd())
+# Add project root to PYTHONPATH so tests work when executed from the
+# tests directory or via CI tools where the working directory may not be
+# the repository root.
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 from backup import backup_manager
 
 

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -5,7 +5,10 @@ import os
 pytest.importorskip("tkinter")
 pytest.importorskip("openai")
 
-sys.path.insert(0, os.getcwd())
+# Add project root to PYTHONPATH so tests work when executed from the
+# tests directory or via CI tools where the working directory may not be
+# the repository root.
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 from interface.autonest_gui import AutoNestGUI
 import tkinter as tk
 

--- a/tests/test_insertion_finder.py
+++ b/tests/test_insertion_finder.py
@@ -2,7 +2,10 @@ import tempfile
 import os
 import sys
 
-sys.path.insert(0, os.getcwd())
+# Add project root to PYTHONPATH so tests work when executed from the
+# tests directory or via CI tools where the working directory may not be
+# the repository root.
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 from core.insertion_finder import find_best_insertion_point
 
 

--- a/tests/test_plugin_loader.py
+++ b/tests/test_plugin_loader.py
@@ -1,7 +1,10 @@
 import sys
 import os
 
-sys.path.insert(0, os.getcwd())
+# Add project root to PYTHONPATH so tests work when executed from the
+# tests directory or via CI tools where the working directory may not be
+# the repository root.
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 from plugins import load_plugins
 
 

--- a/tests/test_project_scanner.py
+++ b/tests/test_project_scanner.py
@@ -2,7 +2,10 @@ import tempfile
 import os
 import sys
 
-sys.path.insert(0, os.getcwd())
+# Add project root to PYTHONPATH so tests work when executed from the
+# tests directory or via CI tools where the working directory may not be
+# the repository root.
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 from core.project_scanner import scan_python_files, extract_structure
 
 


### PR DESCRIPTION
## Summary
- ensure tests add project root to `PYTHONPATH`
- document the reason for adjusting the path
- add GitHub Actions workflow to run pytest

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684484f18f548325b2eae058b38c7d1b