### PR TITLE
Add AUTONEST_USE_GPT environment override

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ Feedback, ideas, and improvements are welcome!
 
 ## Configuration
 Edit `config.json` to configure backup location, GPT usage and a default project path.
+You can also set the environment variable `AUTONEST_USE_GPT` ("1" or "0") to
+override the `use_gpt` option temporarily.
 
 ## Running Tests
 Install dev dependencies and run:

--- a/core/autonest_semantics.py
+++ b/core/autonest_semantics.py
@@ -1,7 +1,16 @@
 # autonest_semantics.py
 
-# Schalter: True = GPT verwenden, False = lokalen Suggestor
-USE_GPT = False  # ← Ändere das später auf True, wenn du GPT willst
+"""Logic for choosing between GPT and local suggestion."""
+
+import os
+from utils.config import load_config
+
+cfg = load_config()
+env_value = os.getenv("AUTONEST_USE_GPT")
+if env_value is not None:
+    USE_GPT = env_value.lower() in ("1", "true", "yes")
+else:
+    USE_GPT = cfg.get("use_gpt", False)
 
 if USE_GPT:
     from core.autonest_gpt import suggest_with_gpt as suggest_logic


### PR DESCRIPTION
## Summary
- read `AUTONEST_USE_GPT` environment variable in `autonest_semantics`
- fall back to config value when env var is not set
- document `AUTONEST_USE_GPT` in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68448e865e8c83259285347a041a005b