### PR TITLE
Fix openai install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,10 @@ AutoNest is a semantic Python code assistant that automatically finds the best p
 See full documentation inside the `/core` and `/interface` directories.
 
 ## Requirements
-See `requirements.txt`
+Install the Python packages listed in `requirements.txt` before running AutoNest. Use:
+```
+pip install -r requirements.txt
+```
 
 ## Usage
 Run the GUI:


### PR DESCRIPTION
## Summary
- document installation of requirements before running AutoNest

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68449d3b655c8325877838e07a90bcc1