### PR TITLE
Handle missing function name with new exception

### DIFF
--- a/core/__init__.py
+++ b/core/__init__.py
@@ -1,13 +1,14 @@
 """Core functionality for AutoNest."""
 
 from .code_inserter import insert_code_into_file, safe_insert_code
-from .insertion_finder import find_best_insertion_point
+from .insertion_finder import find_best_insertion_point, NoFunctionFoundError
 from .project_scanner import scan_project_structure, describe_project_locally
 
 __all__ = [
     "insert_code_into_file",
     "safe_insert_code",
     "find_best_insertion_point",
+    "NoFunctionFoundError",
     "scan_project_structure",
     "describe_project_locally",
     "suggest",

--- a/core/code_inserter.py
+++ b/core/code_inserter.py
@@ -4,7 +4,10 @@ import ast
 import os
 import tempfile
 
-from core.insertion_finder import find_best_insertion_point
+from core.insertion_finder import (
+    find_best_insertion_point,
+    NoFunctionFoundError,
+)
 from backup.backup_manager import create_backup_session, backup_file_to_session
 
 
@@ -12,7 +15,10 @@ def insert_code_into_file(code_str, project_path, modus="neu"):
     """
     Führt die eigentliche Code-Einfügung durch (ohne Backup).
     """
-    match_list = find_best_insertion_point(code_str, project_path)
+    try:
+        match_list = find_best_insertion_point(code_str, project_path)
+    except NoFunctionFoundError as exc:
+        return {"error": str(exc)}
     if not match_list:
         return {"error": "Kein geeigneter Einfügepunkt gefunden"}
 
@@ -96,7 +102,10 @@ def safe_insert_code(code_str, project_path, modus="neu"):
     """
     Kombiniert Backup + Code-Einfügung automatisch.
     """
-    match_list = find_best_insertion_point(code_str, project_path)
+    try:
+        match_list = find_best_insertion_point(code_str, project_path)
+    except NoFunctionFoundError as exc:
+        return {"error": str(exc)}
     if not match_list:
         return {"error": "Kein Einfügepunkt gefunden"}
 

--- a/core/insertion_finder.py
+++ b/core/insertion_finder.py
@@ -6,6 +6,11 @@ from core.project_scanner import scan_project_structure
 from utils.logger import get_logger
 from plugins import load_plugins
 
+
+class NoFunctionFoundError(Exception):
+    """Raised when no valid function definitions are present in the code."""
+
+
 logger = get_logger(__name__)
 
 
@@ -35,7 +40,7 @@ def find_best_insertion_point(code_str, project_path):
     target_names = extract_function_names(code_str)
     if not target_names:
         logger.warning("Keine gültige Funktion im Code gefunden")
-        return {"error": "Keine gültige Funktion erkannt"}
+        raise NoFunctionFoundError("Keine gültige Funktion erkannt")
 
     structure = scan_project_structure(project_path)
     matches = []

--- a/interface/autonest_cli.py
+++ b/interface/autonest_cli.py
@@ -1,7 +1,10 @@
 # autonest_cli.py
 
 from core.code_inserter import insert_code_into_file
-from core.insertion_finder import find_best_insertion_point
+from core.insertion_finder import (
+    find_best_insertion_point,
+    NoFunctionFoundError,
+)
 from pprint import pprint
 import os
 from utils.logger import get_logger
@@ -10,7 +13,11 @@ logger = get_logger(__name__)
 
 
 def decide_mode_and_confirm(code_str, project_path):
-    matches = find_best_insertion_point(code_str, project_path)
+    try:
+        matches = find_best_insertion_point(code_str, project_path)
+    except NoFunctionFoundError as exc:
+        logger.warning(str(exc))
+        return
     if not matches:
         logger.warning("Kein passender Ort im Projekt gefunden.")
         return

--- a/tests/test_insertion_finder.py
+++ b/tests/test_insertion_finder.py
@@ -1,9 +1,10 @@
 import tempfile
 import os
 import sys
+import pytest
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-from core.insertion_finder import find_best_insertion_point
+from core.insertion_finder import find_best_insertion_point, NoFunctionFoundError
 
 
 def test_find_best_insertion_point():
@@ -16,3 +17,10 @@ def test_find_best_insertion_point():
         matches = find_best_insertion_point(code, tmp)
         assert matches
         assert matches[0]["file"] == file1
+
+
+def test_no_function_found_error():
+    with tempfile.TemporaryDirectory() as tmp:
+        code = "print('no func')"
+        with pytest.raises(NoFunctionFoundError):
+            find_best_insertion_point(code, tmp)


### PR DESCRIPTION
## Summary
- introduce `NoFunctionFoundError` in `insertion_finder`
- raise this exception instead of returning an error
- catch the new exception in CLI and code inserter
- expose the exception via `core.__init__`
- add tests for the new behaviour

## Testing
- `black --check .`
- `pytest -q`
- `pip install flake8` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_68453d4c124c832596baf137d7175efa