### PR TITLE
Handle faulty plugins gracefully

### DIFF
--- a/plugins/plugin_loader.py
+++ b/plugins/plugin_loader.py
@@ -2,6 +2,9 @@ import importlib
 import pkgutil
 import os
 from utils.config import load_config, save_config
+from utils.logger import get_logger
+
+logger = get_logger(__name__)
 
 
 def list_plugins():
@@ -28,7 +31,11 @@ def load_plugins():
             continue
         if name in active and not active[name]:
             continue
-        module = importlib.import_module(f"{__package__}.{name}")
+        try:
+            module = importlib.import_module(f"{__package__}.{name}")
+        except ImportError as exc:
+            logger.warning("Plugin '%s' konnte nicht geladen werden: %s", name, str(exc))
+            continue
         if hasattr(module, "get_rules"):
             plugins.extend(module.get_rules())
     return plugins

--- a/tests/test_plugin_loader.py
+++ b/tests/test_plugin_loader.py
@@ -19,3 +19,23 @@ def test_plugin_can_be_disabled(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     rules = load_plugins()
     assert not rules
+
+
+def test_faulty_plugin_is_skipped(monkeypatch):
+    plugin_dir = os.path.join(os.path.dirname(__file__), "..", "plugins")
+    faulty_path = os.path.join(plugin_dir, "faulty_plugin.py")
+    with open(faulty_path, "w", encoding="utf-8") as fh:
+        fh.write('raise ImportError("boom")')
+
+    warnings = []
+    from plugins import plugin_loader
+
+    monkeypatch.setattr(
+        plugin_loader.logger, "warning", lambda *args, **kwargs: warnings.append(args)
+    )
+    try:
+        rules = plugin_loader.load_plugins()
+        assert any(callable(r) for r in rules)
+        assert warnings
+    finally:
+        os.remove(faulty_path)


### PR DESCRIPTION
## Summary
- guard plugin loading with `try/except ImportError`
- warn if plugin import fails and skip it
- add test verifying faulty plugin is skipped

## Testing
- `black --check plugins/plugin_loader.py tests/test_plugin_loader.py`
- `pytest -q`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68453f73efc883258539cef0afe4bdc9