### PR TITLE
Add recent entries viewer

### DIFF
--- a/tests/test_memory_context_manager.py
+++ b/tests/test_memory_context_manager.py
@@ -1,0 +1,24 @@
+import os
+import tempfile
+from backup import memory_context_manager as mcm
+
+
+def test_save_and_load_recent_entries():
+    with tempfile.TemporaryDirectory() as tmp:
+        suggestion = {
+            "ziel_datei": "foo.py",
+            "ziel_funktion": "bar",
+            "vermuteter_modus": "neu",
+            "sicherheit": "hoch",
+        }
+        # clear to start
+        mcm.clear_memory(tmp)
+        for i in range(7):
+            mcm.save_context_entry(tmp, suggestion, f"print({i})")
+        entries = mcm.load_recent_entries(tmp)
+        assert len(entries) == 5
+        assert entries[-1]["raw_code"] == "print(6)"
+        # limit 2
+        entries2 = mcm.load_recent_entries(tmp, limit=2)
+        assert len(entries2) == 2
+        assert entries2[0]["raw_code"] == "print(5)"

--- a/utils/i18n.py
+++ b/utils/i18n.py
@@ -34,6 +34,8 @@ _TRANSLATIONS = {
         "Module verwalten": "Manage modules",
         "Speichern": "Save",
         "Modulstatus gespeichert.": "Module status saved.",
+        "Zuletzt eingefügt": "Recently inserted",
+        "Keine Einträge gefunden.": "No entries found.",
     },
     "de": {
         "Pfad fehlt": "Pfad fehlt",
@@ -66,6 +68,8 @@ _TRANSLATIONS = {
         "Module verwalten": "Module verwalten",
         "Speichern": "Speichern",
         "Modulstatus gespeichert.": "Modulstatus gespeichert.",
+        "Zuletzt eingefügt": "Zuletzt eingefügt",
+        "Keine Einträge gefunden.": "Keine Einträge gefunden.",
     },
     "fr": {
         "Pfad fehlt": "Chemin manquant",
@@ -98,6 +102,8 @@ _TRANSLATIONS = {
         "Module verwalten": "G\u00e9rer les modules",
         "Speichern": "Enregistrer",
         "Modulstatus gespeichert.": "Statut du module enregistr\u00e9.",
+        "Zuletzt eingefügt": "R\u00e9cemment ins\u00e9r\u00e9",
+        "Keine Einträge gefunden.": "Aucune entr\u00e9e trouv\u00e9e.",
     },
 }
 


### PR DESCRIPTION
## Summary
- show a button to view recently inserted code
- implement window to display recent entries from memory
- store entries when code gets inserted
- translate new GUI labels
- test memory context manager saving/loading

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68454137284c8325849608da76b498b9