### PR TITLE
Optimize GPT project summary usage

### DIFF
--- a/core/autonest_semantics.py
+++ b/core/autonest_semantics.py
@@ -13,15 +13,15 @@ else:
     USE_GPT = cfg.get("use_gpt", False)
 
 if USE_GPT:
-    from core.autonest_gpt import suggest_with_gpt as suggest_logic
-    from core.project_scanner import scan_project_structure
+    from core.autonest_suggestor import suggest_insertion as suggest_logic
+    from core.autonest_gpt import describe_project_with_gpt
 else:
     from core.autonest_suggestor import suggest_insertion as suggest_logic
 
 
 def suggest(code_str, project_path):
     if USE_GPT:
-        structure = scan_project_structure(project_path)
-        return suggest_logic(code_str, structure)
+        project_summary = describe_project_with_gpt(project_path)
+        return suggest_logic(code_str, project_summary=project_summary)
     else:
-        return suggest_logic(code_str, project_path)
+        return suggest_logic(code_str, project_path=project_path)

--- a/core/autonest_suggestor.py
+++ b/core/autonest_suggestor.py
@@ -5,12 +5,12 @@ from core.autonest_gpt import build_prompt, describe_project_with_gpt
 openai_api_key = os.getenv("OPENAI_API_KEY")
 
 
-def suggest_insertion(code_str, project_path):
-    """
-    Führt eine semantische Analyse durch und gibt GPT-Vorschlag zurück.
-    """
-    # Projektbeschreibung erzeugen (strukturbasiert)
-    project_summary = describe_project_with_gpt(project_path)
+def suggest_insertion(code_str, project_summary=None, project_path=None):
+    """Return GPT suggestion for inserting ``code_str`` into a project."""
+    if project_summary is None:
+        if project_path is None:
+            raise ValueError("project_path or project_summary required")
+        project_summary = describe_project_with_gpt(project_path)
 
     # Prompt generieren
     prompt = build_prompt(code_str, project_summary)

--- a/tests/test_autonest_semantics.py
+++ b/tests/test_autonest_semantics.py
@@ -1,0 +1,43 @@
+import os
+import sys
+import importlib
+import types
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+
+def test_suggest_describes_project_once(monkeypatch):
+    fake_openai = types.SimpleNamespace(
+        ChatCompletion=types.SimpleNamespace(
+            create=lambda *a, **k: {"choices": [{"message": {"content": ""}}]}
+        )
+    )
+    monkeypatch.setitem(sys.modules, "openai", fake_openai)
+
+    os.environ["AUTONEST_USE_GPT"] = "1"
+    import core.autonest_semantics as semantics
+
+    importlib.reload(semantics)
+
+    calls = []
+
+    def fake_desc(path):
+        calls.append(path)
+        return "summary"
+
+    monkeypatch.setattr(semantics, "describe_project_with_gpt", fake_desc)
+
+    captured = {}
+
+    def fake_logic(code_str, project_summary=None, project_path=None):
+        captured["summary"] = project_summary
+        captured["path"] = project_path
+        return {}
+
+    monkeypatch.setattr(semantics, "suggest_logic", fake_logic)
+
+    semantics.suggest("code", "/tmp/proj")
+
+    assert calls == ["/tmp/proj"]
+    assert captured["summary"] == "summary"
+    assert captured["path"] is None


### PR DESCRIPTION
## Summary
- refactor GPT usage in `autonest_semantics` to generate project summary once
- update `suggest_insertion` to allow cached summary input
- add regression test ensuring single GPT project description call

## Testing
- `black core/autonest_semantics.py core/autonest_suggestor.py tests/test_autonest_semantics.py --check`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68454e3a4c108325ace0547aa29124b5