### PR TITLE
Improve project scanner import detection

### DIFF
--- a/core/project_scanner.py
+++ b/core/project_scanner.py
@@ -56,6 +56,7 @@ def scan_project_structure(project_path):
 
 def describe_project_locally(project_path):
     import os
+    import ast
 
     function_count = 0
     class_count = 0
@@ -64,16 +65,33 @@ def describe_project_locally(project_path):
     for root, _, files in os.walk(project_path):
         for file in files:
             if file.endswith(".py"):
-                with open(os.path.join(root, file), encoding="utf-8") as f:
-                    lines = f.readlines()
+                full_path = os.path.join(root, file)
+                with open(full_path, encoding="utf-8") as f:
+                    source = f.read()
+
+                lines = source.splitlines()
                 for line in lines:
                     if line.strip().startswith("def "):
                         function_count += 1
                     elif line.strip().startswith("class "):
                         class_count += 1
-                    elif "import " in line or "from " in line:
-                        parts = line.replace(",", " ").split()
-                        modules.update(p for p in parts if p not in {"import", "from", "as"})
+
+                try:
+                    tree = ast.parse(source, filename=full_path)
+                except SyntaxError:
+                    continue
+
+                for node in ast.walk(tree):
+                    if isinstance(node, ast.Import):
+                        for alias in node.names:
+                            modules.add(alias.name)
+                    elif isinstance(node, ast.ImportFrom):
+                        module_base = node.module or ""
+                        for alias in node.names:
+                            if module_base:
+                                modules.add(f"{module_base}.{alias.name}")
+                            else:
+                                modules.add(alias.name)
 
     return f"Funktionen: {function_count}\nKlassen: {class_count}\nVerwendete Module: {', '.join(sorted(modules))}"
 

--- a/tests/test_project_scanner.py
+++ b/tests/test_project_scanner.py
@@ -3,7 +3,11 @@ import os
 import sys
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-from core.project_scanner import scan_python_files, extract_structure
+from core.project_scanner import (
+    scan_python_files,
+    extract_structure,
+    describe_project_locally,
+)
 
 
 def test_scan_python_files_and_structure():
@@ -16,3 +20,18 @@ def test_scan_python_files_and_structure():
         structure = extract_structure(file1)
         assert "A" in structure["classes"]
         assert "func" in structure["functions"]
+
+
+def test_describe_project_locally_imports():
+    with tempfile.TemporaryDirectory() as tmp:
+        file1 = os.path.join(tmp, "mod.py")
+        with open(file1, "w", encoding="utf-8") as f:
+            f.write(
+                """import os\nfrom pkg import mod as m\n\nclass B:\n    pass\n\ndef func():\n    pass\n"""
+            )
+
+        result = describe_project_locally(tmp)
+        assert "Funktionen: 1" in result
+        assert "Klassen: 1" in result
+        assert "os" in result
+        assert "pkg.mod" in result


### PR DESCRIPTION
## Summary
- use `ast` to parse imports in `describe_project_locally`
- ensure `from pkg import mod as m` is parsed correctly
- test updated import detection

## Testing
- `pytest -q`
- `flake8` *(fails: command not found)*
- `black --check core/project_scanner.py tests/test_project_scanner.py`


------
https://chatgpt.com/codex/tasks/task_e_68455263c5f48325b744a12065ed2c48