### PR TITLE
Fix flake8 style errors

### DIFF
--- a/core/project_scanner.py
+++ b/core/project_scanner.py
@@ -93,7 +93,10 @@ def describe_project_locally(project_path):
                             else:
                                 modules.add(alias.name)
 
-    return f"Funktionen: {function_count}\nKlassen: {class_count}\nVerwendete Module: {', '.join(sorted(modules))}"
+    return (
+        f"Funktionen: {function_count}\nKlassen: {class_count}\nVerwendete "
+        f"Module: {', '.join(sorted(modules))}"
+    )
 
 
 # Beispielnutzung (zum Testen):

--- a/interface/autonest_gui.py
+++ b/interface/autonest_gui.py
@@ -148,9 +148,16 @@ class AutoNestGUI:
             color = "red"
             symbol = "❌"
 
-        status_text = f"{symbol}  Modus: {modus.upper()}  |  Datei: {datei}  |  Funktion: {funktion}  |  Sicherheit: {sicherheit.upper()}"
+        status_text = (
+            f"{symbol}  Modus: {modus.upper()}  |  Datei: {datei}  |  Funktion: {funktion}  |  "
+            f"Sicherheit: {sicherheit.upper()}"
+        )
 
-        self.result_label.config(text=status_text, fg=color, font=("Arial", 10, "bold"))
+        self.result_label.config(
+            text=status_text,
+            fg=color,
+            font=("Arial", 10, "bold"),
+        )
 
     def insert_code(self):
         if not self.suggestion:
@@ -175,7 +182,11 @@ class AutoNestGUI:
             save_context_entry(path, self.suggestion, code)
             messagebox.showinfo(
                 t("Erfolg"),
-                f"Code erfolgreich eingefügt!\n\nDatei: {result['datei']}\nModus: {modus}\nBackup: {result['backup_session']}",
+                (
+                    "Code erfolgreich eingefügt!\n\n"
+                    f"Datei: {result['datei']}\nModus: {modus}\n"
+                    f"Backup: {result['backup_session']}"
+                ),
             )
 
     def open_restore_window(self):
@@ -225,7 +236,9 @@ class AutoNestGUI:
     def open_recent_entries(self):
         path = self.project_path.get().strip()
         if not path:
-            messagebox.showwarning(t("Pfad fehlt"), t("Bitte zuerst ein Projektverzeichnis wählen."))
+            messagebox.showwarning(
+                t("Pfad fehlt"), t("Bitte zuerst ein Projektverzeichnis wählen.")
+            )
             return
 
         entries = load_recent_entries(path)
@@ -240,7 +253,10 @@ class AutoNestGUI:
         txt = tk.Text(win, wrap="word")
         txt.pack(fill="both", expand=True)
         for entry in entries:
-            header = f"{entry['timestamp']} - {entry['file_target']}::{entry['function_target']} [{entry['mode']}]"
+            header = (
+                f"{entry['timestamp']} - {entry['file_target']}::"
+                f"{entry['function_target']} [{entry['mode']}]"
+            )
             txt.insert("end", header + "\n")
             txt.insert("end", entry["raw_code"] + "\n\n")
         txt.config(state="disabled")

--- a/tests/test_project_scanner.py
+++ b/tests/test_project_scanner.py
@@ -27,7 +27,12 @@ def test_describe_project_locally_imports():
         file1 = os.path.join(tmp, "mod.py")
         with open(file1, "w", encoding="utf-8") as f:
             f.write(
-                """import os\nfrom pkg import mod as m\n\nclass B:\n    pass\n\ndef func():\n    pass\n"""
+                (
+                    "import os\n"
+                    "from pkg import mod as m\n\n"
+                    "class B:\n    pass\n\n"
+                    "def func():\n    pass\n"
+                )
             )
 
         result = describe_project_locally(tmp)

--- a/utils/i18n.py
+++ b/utils/i18n.py
@@ -59,9 +59,13 @@ _TRANSLATIONS = {
         "Datei innerhalb der Session:": "Datei innerhalb der Session:",
         "Fehlende Auswahl": "Fehlende Auswahl",
         "Wiederherstellen": "Wiederherstellen",
-        "Bitte zuerst ein Projektverzeichnis wählen.": "Bitte zuerst ein Projektverzeichnis wählen.",
+        "Bitte zuerst ein Projektverzeichnis wählen.": (
+            "Bitte zuerst ein Projektverzeichnis wählen."
+        ),
         "Fehler bei GPT": "Fehler bei GPT",
-        "Bitte zuerst auf 'Analyse starten' klicken.": "Bitte zuerst auf 'Analyse starten' klicken.",
+        "Bitte zuerst auf 'Analyse starten' klicken.": (
+            "Bitte zuerst auf 'Analyse starten' klicken."
+        ),
         "Bitte Code und Projektpfad angeben.": "Bitte Code und Projektpfad angeben.",
         "Bitte Session und Datei wählen.": "Bitte Session und Datei wählen.",
         "Wiederhergestellt": "Wiederhergestellt",
@@ -93,9 +97,13 @@ _TRANSLATIONS = {
         "Datei innerhalb der Session:": "Fichier dans la session :",
         "Fehlende Auswahl": "S\u00e9lection manquante",
         "Wiederherstellen": "Restaurer",
-        "Bitte zuerst ein Projektverzeichnis wählen.": "Veuillez d'abord choisir un r\u00e9pertoire de projet.",
+        "Bitte zuerst ein Projektverzeichnis wählen.": (
+            "Veuillez d'abord choisir un r\u00e9pertoire de projet."
+        ),
         "Fehler bei GPT": "Erreur GPT",
-        "Bitte zuerst auf 'Analyse starten' klicken.": "Veuillez d'abord cliquer sur 'D\u00e9marrer l'analyse'.",
+        "Bitte zuerst auf 'Analyse starten' klicken.": (
+            "Veuillez d'abord cliquer sur 'D\u00e9marrer l'analyse'."
+        ),
         "Bitte Code und Projektpfad angeben.": "Veuillez fournir le code et le chemin du projet.",
         "Bitte Session und Datei wählen.": "Veuillez choisir la session et le fichier.",
         "Wiederhergestellt": "Restaur\u00e9",


### PR DESCRIPTION
## Summary
- shorten long strings that broke flake8 line length checks
- adjust translation file to avoid overlong lines
- wrap long test string for readability

## Testing
- `pytest -q`
- `black --check .`


------
https://chatgpt.com/codex/tasks/task_e_68486e9a870c8325bfa86c528a236b72