### PR TITLE
Add sidebar GUI with logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## [0.3] - 2024-??-??
+### Added
+- Revamped GUI with sidebar navigation, logs panel, and project settings.
+

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="autonest",
-    version="0.2",
+    version="0.3",
     packages=find_packages(),
     install_requires=["openai", "requests"],
     entry_points={"console_scripts": ["autonest-gui=interface.autonest_gui:main"]},


### PR DESCRIPTION
## Summary
- update GUI with sidebar navigation and results panel
- add log text handler and project settings
- bump version to 0.3
- document changes in CHANGELOG

## Testing
- `pytest -q`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684879cb2aa083258572cde89e34194e