### PR TITLE
Add engine/agent modules with documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,4 +4,5 @@
 ### Added
 - Revamped GUI with sidebar navigation, logs panel, and project settings.
 - Updated version references to v0.3 in README and GUI.
+- Documented new ``core.engine`` and ``core.agent`` modules.
 

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -3,6 +3,8 @@
 from .code_inserter import insert_code_into_file, safe_insert_code
 from .insertion_finder import find_best_insertion_point, NoFunctionFoundError
 from .project_scanner import scan_project_structure, describe_project_locally
+from .engine import AutoNestEngine
+from .agent import AutoNestAgent
 
 __all__ = [
     "insert_code_into_file",
@@ -12,6 +14,8 @@ __all__ = [
     "scan_project_structure",
     "describe_project_locally",
     "suggest",
+    "AutoNestEngine",
+    "AutoNestAgent",
 ]
 
 

--- a/core/agent.py
+++ b/core/agent.py
@@ -1,0 +1,40 @@
+"""Simple agent abstraction for AutoNest.
+
+The agent acts as a thin wrapper around :class:`AutoNestEngine` and can be used
+by CLI or GUI components to process user provided code blocks.
+"""
+
+from __future__ import annotations
+
+from .engine import AutoNestEngine
+
+__all__ = ["AutoNestAgent"]
+
+
+class AutoNestAgent:
+    """High level helper that delegates work to :class:`AutoNestEngine`."""
+
+    def __init__(self, project_path: str) -> None:
+        """Create an agent operating on ``project_path``."""
+
+        self.engine = AutoNestEngine(project_path)
+
+    def process(self, code_str: str, mode: str = "neu") -> dict:
+        """Run suggestion and insertion for ``code_str``.
+
+        Parameters
+        ----------
+        code_str:
+            The new code snippet to insert or extend.
+        mode:
+            Insertion mode passed to :meth:`AutoNestEngine.insert`.
+
+        Returns
+        -------
+        dict
+            Mapping with ``suggestion`` and ``result`` entries.
+        """
+
+        suggestion = self.engine.suggest(code_str)
+        result = self.engine.insert(code_str, mode)
+        return {"suggestion": suggestion, "result": result}

--- a/core/engine.py
+++ b/core/engine.py
@@ -1,0 +1,46 @@
+"""High-level orchestration for AutoNest tasks.
+
+This module provides :class:`AutoNestEngine`, a helper that coordinates
+suggestion and insertion logic when working with a project.
+"""
+
+from __future__ import annotations
+
+from .code_inserter import safe_insert_code
+
+
+__all__ = ["AutoNestEngine"]
+
+
+class AutoNestEngine:
+    """Simple wrapper for performing AutoNest operations."""
+
+    def __init__(self, project_path: str) -> None:
+        """Create a new engine bound to ``project_path``."""
+
+        self.project_path = project_path
+
+    def suggest(self, code_str: str):
+        """Return a suggestion about how to handle ``code_str``."""
+        from . import autonest_semantics
+
+        return autonest_semantics.suggest(code_str, self.project_path)
+
+    def insert(self, code_str: str, mode: str = "neu") -> dict:
+        """Insert ``code_str`` into the project.
+
+        Parameters
+        ----------
+        code_str:
+            The code block to insert.
+        mode:
+            Either ``"neu"`` to create a new block or ``"erweitern"`` to
+            extend an existing one.
+
+        Returns
+        -------
+        dict
+            The result from :func:`safe_insert_code`.
+        """
+
+        return safe_insert_code(code_str, self.project_path, modus=mode)


### PR DESCRIPTION
## Summary
- add `core.engine` module
- add `core.agent` module
- export engine and agent from `core.__init__`
- document new modules in `CHANGELOG`

## Testing
- `black --check core/engine.py core/agent.py core/__init__.py`
- `flake8` *(fails: command not found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d9c8785cc8325bc5908d587fbbbf6