### PR TITLE
Handle plugin rule loading failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,8 @@
 - Revamped GUI with sidebar navigation, logs panel, and project settings.
 - Updated version references to v0.3 in README and GUI.
 
+## [0.3.1] - 2024-??-??
+### Fixed
+- Plugin loader now skips plugins whose `get_rules()` function raises an
+  exception and logs a warning instead of failing.
+

--- a/README.md
+++ b/README.md
@@ -11,6 +11,11 @@ AutoNest is a semantic Python code assistant that automatically finds the best p
 - Plugin system for custom rules
 - URL fetching utility via `utils.network_scanner`
 
+## Plugins
+Plugins live in `plugins/` and provide additional rule sets. During loading,
+AutoNest calls each plugin's `get_rules()` function. If this call raises an
+exception, the plugin is skipped and a warning is emitted.
+
 See full documentation inside the `/core` and `/interface` directories.
 
 ## Requirements

--- a/plugins/plugin_loader.py
+++ b/plugins/plugin_loader.py
@@ -37,5 +37,8 @@ def load_plugins():
             logger.warning("Plugin '%s' konnte nicht geladen werden: %s", name, str(exc))
             continue
         if hasattr(module, "get_rules"):
-            plugins.extend(module.get_rules())
+            try:
+                plugins.extend(module.get_rules())
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("Plugin '%s' konnte nicht initialisiert werden: %s", name, str(exc))
     return plugins

--- a/tests/test_plugin_loader.py
+++ b/tests/test_plugin_loader.py
@@ -39,3 +39,23 @@ def test_faulty_plugin_is_skipped(monkeypatch):
         assert warnings
     finally:
         os.remove(faulty_path)
+
+
+def test_rules_exception_is_skipped(monkeypatch):
+    plugin_dir = os.path.join(os.path.dirname(__file__), "..", "plugins")
+    bad_path = os.path.join(plugin_dir, "bad_rules_plugin.py")
+    with open(bad_path, "w", encoding="utf-8") as fh:
+        fh.write("def get_rules():\n    raise RuntimeError('fail')\n")
+
+    warnings = []
+    from plugins import plugin_loader
+
+    monkeypatch.setattr(
+        plugin_loader.logger, "warning", lambda *args, **kwargs: warnings.append(args)
+    )
+    try:
+        rules = plugin_loader.load_plugins()
+        assert any(callable(r) for r in rules)
+        assert warnings
+    finally:
+        os.remove(bad_path)


### PR DESCRIPTION
## Summary
- safeguard plugin rule loading in `load_plugins`
- test failure handling when a plugin's `get_rules` raises
- document plugin error handling
- note patch in changelog

## Testing
- `pytest -q`
- `flake8` *(fails: command not found)*
- `python -m compileall -q .`


------
https://chatgpt.com/codex/tasks/task_e_684d9c88f35083259f8f9324011da329