### PR TITLE
Add unified main entry point

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,4 +4,5 @@
 ### Added
 - Revamped GUI with sidebar navigation, logs panel, and project settings.
 - Updated version references to v0.3 in README and GUI.
+- New unified entry point `core.main` for CLI and GUI usage.
 

--- a/README.md
+++ b/README.md
@@ -22,18 +22,18 @@ pip install -r requirements.txt
 ## Usage
 Run the GUI:
 ```
-python interface/autonest_gui.py
+python -m core.main gui
 ```
 Run the CLI:
 ```
-python interface/autonest_cli.py
+python -m core.main cli
 ```
 Use the restore tool to recover backups:
 ```
-python interface/restore_tool.py
+python -m core.main restore
 ```
-After installing with `setup.py`, you can also launch the GUI using the
-`autonest-gui` command provided by the console script entry point.
+After installing with `setup.py`, you can launch AutoNest using the
+`autonest` command provided by the console script entry point.
 ### About the Author
 
 This is my very first Python project. I built AutoNest to learn,

--- a/core/main.py
+++ b/core/main.py
@@ -1,0 +1,31 @@
+import argparse
+
+
+def main(argv=None):
+    """Unified command-line entry point for AutoNest."""
+    parser = argparse.ArgumentParser(description="AutoNest launcher")
+    parser.add_argument(
+        "mode",
+        choices=["gui", "cli", "restore"],
+        nargs="?",
+        default="gui",
+        help="Start GUI (default), CLI or restore tool",
+    )
+    args = parser.parse_args(argv)
+
+    if args.mode == "gui":
+        from interface.autonest_gui import main as gui_main
+
+        gui_main()
+    elif args.mode == "cli":
+        from interface.autonest_cli import main as cli_main
+
+        cli_main()
+    else:  # restore
+        from interface.restore_tool import main as restore_main
+
+        restore_main()
+
+
+if __name__ == "__main__":
+    main()

--- a/interface/autonest_cli.py
+++ b/interface/autonest_cli.py
@@ -45,8 +45,8 @@ def decide_mode_and_confirm(code_str, project_path):
         logger.info("Abgebrochen.")
 
 
-# Beispielnutzung:
-if __name__ == "__main__":
+def main() -> None:
+    """Command-line interface entry point."""
     pfad = input("Pfad zum Projekt: ").strip()
     print("Bitte füge deinen Code ein (Beende mit Leerzeile):")
 
@@ -59,3 +59,7 @@ if __name__ == "__main__":
 
     code = "\n".join(lines)
     decide_mode_and_confirm(code, pfad)
+
+
+if __name__ == "__main__":
+    main()

--- a/interface/restore_tool.py
+++ b/interface/restore_tool.py
@@ -59,5 +59,10 @@ def restore_workflow():
     logger.info(result)
 
 
-if __name__ == "__main__":
+def main() -> None:
+    """Entry point for the restore tool."""
     restore_workflow()
+
+
+if __name__ == "__main__":
+    main()

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ setup(
     version="0.3",
     packages=find_packages(),
     install_requires=["openai", "requests"],
-    entry_points={"console_scripts": ["autonest-gui=interface.autonest_gui:main"]},
+    entry_points={"console_scripts": ["autonest=core.main:main"]},
     author="Solen",
     description="Semantic Python code inserter with GPT and GUI support",
 )


### PR DESCRIPTION
## Summary
- add `core/main.py` with new CLI/GUI entry point
- expose `main()` in CLI and restore modules
- document new entry point in README
- update console script and changelog

## Testing
- `black --check .`
- `flake8` *(fails: command not found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d9c8af95c8325b43476e4cf6f24dc